### PR TITLE
Allow user-defined logging behaviour.

### DIFF
--- a/powerplantmatching/core.py
+++ b/powerplantmatching/core.py
@@ -52,7 +52,6 @@ if not os.path.exists(_data_in('.')):
 
 # Logging: General Settings
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=20)
 logger.setLevel('INFO')
 # Logging: File
 logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] " +


### PR DESCRIPTION
Calling `logging.basicConfig(...)` in the module outside a user's `__main__` threads somehow blocks user-defined configurations issued by subsequent `logging.basicConfig(...)` calls.

See the [logging documentation](https://docs.python.org/3/library/logging.html#logging.basicConfig).