### PR TITLE
Add OPSD VRE database to config for available countries

### DIFF
--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1109,8 +1109,8 @@ def OPSD_VRE(config=None, raw=False):
 
 def OPSD_VRE_country(country, config=None, raw=False):
     """
-    Get country specifig data from OPSD for renewables. For using this,
-    the config has to be adjusted.
+    Get country specifig data from OPSD for renewables, if available.
+    Available for DE, FR, PL, CH, DK, CZ and SE (last update: 09/2020).
     """
     config = get_config() if config is None else config
 

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1114,7 +1114,7 @@ def OPSD_VRE_country(country, config=None, raw=False):
     """
     config = get_config() if config is None else config
 
-    df = parse_if_not_stored(f'OPSD_VRE_{country}')
+    df = parse_if_not_stored(f'OPSD_VRE_{country}', low_memory=False)
     if raw:
         return df
 

--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1118,7 +1118,7 @@ def OPSD_VRE_country(country, config=None, raw=False):
     if raw:
         return df
 
-    return (df.assign(Country='DE')
+    return (df.assign(Country=country)
               .rename(columns={'energy_source_level_2': 'Fueltype',
                                'technology': 'Technology',
                                'data_source': 'file',

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -82,8 +82,29 @@ OPSD_EU:
   fn: conventional_power_plants_EU.csv
   url: https://data.open-power-system-data.org/conventional_power_plants/2018-12-20/conventional_power_plants_EU.csv
 OPSD_VRE:
-  url: https://data.open-power-system-data.org/renewable_power_plants/2019-04-05/renewable_power_plants_EU.csv
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_EU.csv
   fn: renewable_power_plants_EU.csv
+OPSD_VRE_DE:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_DE.csv
+  fn: renewable_power_plants_DE.csv
+OPSD_VRE_FR:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_FR.csv
+  fn: renewable_power_plants_FR.csv
+OPSD_VRE_PL:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_PL.csv
+  fn: renewable_power_plants_PL.csv
+OPSD_VRE_CH:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_CH.csv
+  fn: renewable_power_plants_CH.csv
+OPSD_VRE_DK:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_DK.csv
+  fn: renewable_power_plants_DK.csv
+OPSD_VRE_CZ:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_CZ.csv
+  fn: renewable_power_plants_CZ.csv
+OPSD_VRE_SE:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_SE.csv
+  fn: renewable_power_plants_SE.csv
 OPSD:
   reliability_score: 5
 Capacity_stats:


### PR DESCRIPTION
Instead of having to add the OPSD data manually to the config, provide an initial version (2020/08/25), update Europe to the same version.

Available countries at the moment are:
DE, FR, PL, CH, DK, UK, CZ and SE.

small bug-fix in OPSD_VRE_country, where the country was set initially to Germany.