### PR TITLE
Add OPSD VRE database to config for GB

### DIFF
--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -1114,7 +1114,7 @@ def OPSD_VRE_country(country, config=None, raw=False):
     """
     config = get_config() if config is None else config
 
-    df = parse_if_not_stored(f'OPSD_VRE_{country}', low_memory=False)
+    df = parse_if_not_stored(f'OPSD_VRE_{country}', engine='python')
     if raw:
         return df
 
@@ -1122,7 +1122,7 @@ def OPSD_VRE_country(country, config=None, raw=False):
               .rename(columns={'energy_source_level_2': 'Fueltype',
                                'technology': 'Technology',
                                'data_source': 'file',
-                               'country': 'Country',
+                               # 'country': 'Country', # (breaks code for GB if included)
                                'electrical_capacity': 'Capacity',
                                'municipality': 'Name'})
               .powerplant.convert_alpha2_to_country()

--- a/powerplantmatching/package_data/config.yaml
+++ b/powerplantmatching/package_data/config.yaml
@@ -105,6 +105,9 @@ OPSD_VRE_CZ:
 OPSD_VRE_SE:
   url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_SE.csv
   fn: renewable_power_plants_SE.csv
+OPSD_VRE_GB:
+  url: https://data.open-power-system-data.org/renewable_power_plants/2020-08-25/renewable_power_plants_UK.csv
+  fn: renewable_power_plants_UK.csv
 OPSD:
   reliability_score: 5
 Capacity_stats:


### PR DESCRIPTION
There were some issues with GB (i.e. `engine` has to be specified as `python`, is not compatible with `low_memory=False` and `alpha_2` name is not conform to ISO 3166-1 alpha2 - hence the url ends with `UK`, but country is `GB`)

Therefore this separate PR (and not included in #33)