### PR TITLE
data.Capacity_stats: year should be int, not str

### DIFF
--- a/powerplantmatching/data.py
+++ b/powerplantmatching/data.py
@@ -365,7 +365,7 @@ def IWPDCY(config=None):
 
 
 def Capacity_stats(raw=False, level=2, config=None, update=False,
-                   source='entsoe SO&AF', year='2016'):
+                   source='entsoe SO&AF', year=2016):
     """
     Standardize the aggregated capacity statistics provided by the ENTSO-E.
 


### PR DESCRIPTION
this is also outlined in the description of the function; see
https://github.com/FRESNA/powerplantmatching/blob/master/powerplantmatching/data.py#L374

if str (for examplte the default value) it always returns an empty dataframe.