### PR TITLE
Added entso-py to requirements.yaml

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -20,3 +20,4 @@ dependencies:
   - pip:
     - pycountry
     - quilt
+    - entsoe-py


### PR DESCRIPTION
Everytime I create an environment using the requirements.yaml I have to install entso-py manually, I suggest this change to avoid doing that.